### PR TITLE
Initialize task DAG and extension skeleton

### DIFF
--- a/DevDiary.md
+++ b/DevDiary.md
@@ -1,3 +1,4 @@
 # Development Diary
 
 - INIT - This repo has been made as Blueprint so we can scan projectscope.md and Construct the perfect self iterating Project! Glueckauf Robokind!
+- bc756a2e Planning completed. Created DAG and initial state.

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -11,3 +11,186 @@
 ---
 
 ### ***Agent Prio Tasks:***
+---
+- uuid: cd6121a1
+  parent: bc756a2e
+  description: Parse projectscope and design milestones
+  why: Break down goals into actionable items
+  depends_on: []
+  status: [x]
+---
+- uuid: 0e733c6b
+  parent: bc756a2e
+  description: Update task files, metrics, and state
+  why: Record initial planning information
+  depends_on: [cd6121a1]
+  status: [x]
+---
+- uuid: e19adce7
+  parent: bc756a2e
+  description: Generate initial taskmap.svg
+  why: Visual reference of project timeline
+  depends_on: [0e733c6b]
+  status: [x]
+---
+- uuid: 96a1b336
+  parent: 55b22049
+  description: Request ChatGPT DOM dump from user
+  why: Need accurate selectors for automation
+  depends_on: []
+  status: [u]
+---
+- uuid: a20ccaaa
+  parent: 55b22049
+  description: Request Codex DOM dump from user
+  why: Need accurate selectors for automation
+  depends_on: []
+  status: [u]
+---
+- uuid: a057f02e
+  parent: 55b22049
+  description: Analyze DOM dumps and document selectors
+  why: Provide reliable hooks for scripts
+  depends_on: [96a1b336, a20ccaaa]
+  status: []
+---
+- uuid: b79cc393
+  parent: 8d468653
+  description: Create extension manifest using MV3
+  why: Chrome/Firefox extension base configuration
+  depends_on: [a057f02e]
+  status: []
+---
+- uuid: 532b4a5c
+  parent: 8d468653
+  description: Scaffold background script
+  why: Manage headless interactions and queue
+  depends_on: [b79cc393]
+  status: []
+---
+- uuid: 885bad7c
+  parent: 8d468653
+  description: Scaffold content script
+  why: Interface with page DOM
+  depends_on: [b79cc393]
+  status: []
+---
+- uuid: 649d87e9
+  parent: 8d468653
+  description: Update repository manifest with extension files
+  why: Track new artifacts for agents
+  depends_on: [532b4a5c, 885bad7c]
+  status: []
+---
+- uuid: 0572df48
+  parent: 8d468653
+  description: Run MetaStateChecker after skeleton implementation
+  why: Verify milestone integration
+  depends_on: [649d87e9]
+  status: []
+---
+- uuid: b35f9be0
+  parent: e8e121d2
+  description: Implement ChatGPT read/write helpers
+  why: Allow extension to send and receive prompts
+  depends_on: [a057f02e, 649d87e9]
+  status: []
+---
+- uuid: 8968c023
+  parent: e8e121d2
+  description: Detect ChatGPT response completion
+  why: Know when to capture output and send next prompt
+  depends_on: [b35f9be0]
+  status: []
+---
+- uuid: a6d5ea2f
+  parent: e8e121d2
+  description: Capture ChatGPT output text
+  why: Return generated responses to agent framework
+  depends_on: [8968c023]
+  status: []
+---
+- uuid: bbfc3e82
+  parent: e8e121d2
+  description: Run MetaStateChecker for ChatGPT handlers
+  why: Ensure reliability before continuing
+  depends_on: [a6d5ea2f]
+  status: []
+---
+- uuid: 7045ec12
+  parent: 295fe504
+  description: Implement Codex read/write helpers
+  why: Automate Codex interactions
+  depends_on: [a057f02e, 649d87e9]
+  status: []
+---
+- uuid: d4a56894
+  parent: 295fe504
+  description: Detect Codex response completion
+  why: Trigger capture and next prompt
+  depends_on: [7045ec12]
+  status: []
+---
+- uuid: 5ee32f69
+  parent: 295fe504
+  description: Capture Codex output text
+  why: Provide responses back to agent framework
+  depends_on: [d4a56894]
+  status: []
+---
+- uuid: 7146df7c
+  parent: 295fe504
+  description: Run MetaStateChecker for Codex handlers
+  why: Validate DOM automation stage
+  depends_on: [5ee32f69]
+  status: []
+---
+- uuid: bd305eed
+  parent: a57eb7aa
+  description: Implement shared prompt queue manager
+  why: Coordinate multiple prompts across platforms
+  depends_on: [bbfc3e82, 7146df7c]
+  status: []
+---
+- uuid: 89f8dcf4
+  parent: a57eb7aa
+  description: Integrate completion detection with queue
+  why: Automatically issue next prompt when ready
+  depends_on: [bd305eed]
+  status: []
+---
+- uuid: 71a3f231
+  parent: a57eb7aa
+  description: Send captured outputs to agent framework
+  why: Provide data for higher-level automation
+  depends_on: [89f8dcf4]
+  status: []
+---
+- uuid: 62540b33
+  parent: a57eb7aa
+  description: Run MetaStateChecker for queue manager
+  why: Confirm stable automation loop
+  depends_on: [71a3f231]
+  status: []
+---
+- uuid: 6946d58d
+  parent: 7be14b8e
+  description: Finalize documentation and examples
+  why: Help users understand extension usage
+  depends_on: [62540b33]
+  status: []
+---
+- uuid: 3cbba0f3
+  parent: 7be14b8e
+  description: Update metrics and state for project completion
+  why: Record final task statuses and graph hash
+  depends_on: [6946d58d]
+  status: []
+---
+- uuid: 40927029
+  parent: 7be14b8e
+  description: Run final MetaStateChecker
+  why: Verify repository consistency before closing
+  depends_on: [3cbba0f3]
+  status: []
+---

--- a/agent_tasks.md
+++ b/agent_tasks.md
@@ -10,3 +10,53 @@
 ---
 
 ### ***Project Milestones:***
+---
+- uuid: bc756a2e
+  description: Initial planning and DAG generation
+  why: Establish structured tasks for development
+  depends_on: []
+  priority: 1
+  status: [x]
+---
+- uuid: 55b22049
+  description: Acquire DOM information for ChatGPT and Codex
+  why: Needed to accurately target elements for automation
+  depends_on: [bc756a2e]
+  priority: 2
+  status: []
+---
+- uuid: 8d468653
+  description: Setup browser extension skeleton using Manifest v3
+  why: Provides base framework for DOM interaction
+  depends_on: [55b22049]
+  priority: 3
+  status: []
+---
+- uuid: e8e121d2
+  description: Implement ChatGPT DOM handlers
+  why: Enable read/write and completion detection in ChatGPT UI
+  depends_on: [8d468653]
+  priority: 4
+  status: []
+---
+- uuid: 295fe504
+  description: Implement Codex DOM handlers
+  why: Enable read/write and completion detection in Codex UI
+  depends_on: [e8e121d2]
+  priority: 5
+  status: []
+---
+- uuid: a57eb7aa
+  description: Implement queue management and output capture
+  why: Automate multiple prompts and gather responses
+  depends_on: [295fe504]
+  priority: 6
+  status: []
+---
+- uuid: 7be14b8e
+  description: Finalize project and documentation
+  why: Ensure completeness and run final checks
+  depends_on: [a57eb7aa]
+  priority: 7
+  status: []
+---

--- a/dumps/CHATGPT_DOM_PLACEHOLDER.html
+++ b/dumps/CHATGPT_DOM_PLACEHOLDER.html
@@ -1,0 +1,1 @@
+<!-- placeholder for ChatGPT DOM dump -->

--- a/dumps/CODEX_DOM_PLACEHOLDER.html
+++ b/dumps/CODEX_DOM_PLACEHOLDER.html
@@ -1,0 +1,1 @@
+<!-- placeholder for Codex DOM dump -->

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,23 @@
+// Background script for Chat-Jacker
+// Handles queued prompts and messaging with content scripts
+
+const promptQueue = [];
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'enqueuePrompt') {
+    promptQueue.push(message.prompt);
+    processQueue();
+  } else if (message.type === 'responseCaptured') {
+    console.log('Captured response:', message.text);
+    processQueue();
+  }
+});
+
+function processQueue() {
+  if (promptQueue.length === 0) return;
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    if (tabs[0]) {
+      chrome.tabs.sendMessage(tabs[0].id, { type: 'executePrompt', prompt: promptQueue.shift() });
+    }
+  });
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,31 @@
+// Content script for Chat-Jacker
+// Placeholder selectors until DOM dumps provided
+
+function sendPromptToPage(prompt) {
+  const input = document.querySelector('textarea'); // TODO: replace with real selector
+  if (input) {
+    input.value = prompt;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const form = input.closest('form');
+    if (form) form.dispatchEvent(new Event('submit', { bubbles: true }));
+  }
+}
+
+function checkCompletion() {
+  // TODO: implement detection based on DOM
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'executePrompt') {
+    sendPromptToPage(message.prompt);
+  }
+});
+
+const observer = new MutationObserver(() => {
+  if (checkCompletion()) {
+    const response = document.body.innerText; // TODO: refine selection
+    chrome.runtime.sendMessage({ type: 'responseCaptured', text: response });
+  }
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Chat-Jacker",
+  "version": "0.1",
+  "permissions": ["activeTab", "storage", "scripting"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*", "https://*.codex.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,32 @@
         "agents.md",
         "manifest.json"
       ]
+    },
+    {
+      "uuid": "bc756a2e",
+      "files": [
+        "projectscope.md",
+        "agent_tasks.md",
+        "agent_prio.md",
+        "metrics.md",
+        "state.md",
+        "taskmap.svg"
+      ]
+    },
+    {
+      "uuid": "55b22049",
+      "files": [
+        "dumps/CHATGPT_DOM_PLACEHOLDER.html",
+        "dumps/CODEX_DOM_PLACEHOLDER.html"
+      ]
+    },
+    {
+      "uuid": "8d468653",
+      "files": [
+        "extension/manifest.json",
+        "extension/background.js",
+        "extension/content.js"
+      ]
     }
   ]
 }

--- a/metrics.md
+++ b/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-total_tasks: 0
-completed_tasks: 0
-open_tasks: 0
-critical_path: NULL
+total_tasks: 34
+completed_tasks: 4
+open_tasks: 30
+critical_path: 7be14b8e

--- a/state.md
+++ b/state.md
@@ -1,5 +1,5 @@
 # Planner State
 
-graph_hash: 
-last_task: 
-active_agents:
+graph_hash: d37924ce53e6ceddf20b9c3e991d96fac68a2e7f
+last_task: e19adce7
+active_agents: PlannerAgent

--- a/taskmap.svg
+++ b/taskmap.svg
@@ -1,1 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200">
+  <style>text { font-family: Arial; font-size: 12px; }</style>
+  <text x="10" y="20">bc756a2e - Planning [x]</text>
+  <text x="10" y="40">55b22049 - Gather DOM info []</text>
+  <text x="10" y="60">8d468653 - Extension skeleton []</text>
+  <text x="10" y="80">e8e121d2 - ChatGPT handlers []</text>
+  <text x="10" y="100">295fe504 - Codex handlers []</text>
+  <text x="10" y="120">a57eb7aa - Queue & capture []</text>
+  <text x="10" y="140">7be14b8e - Finalize []</text>
+</svg>


### PR DESCRIPTION
## Summary
- create milestone and subtask plans for Chat-Jacker
- add placeholder DOM dump files
- set up skeleton browser extension (manifest v3, background and content scripts)
- record planner state and metrics
- generate simple taskmap view

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6886b46d8800832e8f7efc868b29f372