### PR TITLE
Planner task update after DOM dumps

### DIFF
--- a/DevDiary.md
+++ b/DevDiary.md
@@ -4,3 +4,4 @@
 - bc756a2e Planning completed. Created DAG and initial state.
 - 55b22049 awaiting DOM dumps. Tasks 96a1b336 and a20ccaaa marked [u]. Cannot proceed with a057f02e.
 - USER LOG: Hello Planner Agent, i have replaced your placeholder dumps with `CHATGPT_DOM.html` and `CODEX_DOM(mainpage).html`
+- PlannerAgent: DOM dumps received. Updated manifest and metrics. Tasks 96a1b336 and a20ccaaa marked complete, enabling a057f02e.

--- a/agent_tasks.md
+++ b/agent_tasks.md
@@ -23,7 +23,7 @@
   why: Needed to accurately target elements for automation
   depends_on: [bc756a2e]
   priority: 2
-  status: []
+  status: [x]
 ---
 - uuid: 8d468653
   description: Setup browser extension skeleton using Manifest v3

--- a/manifest.json
+++ b/manifest.json
@@ -22,8 +22,8 @@
     {
       "uuid": "55b22049",
       "files": [
-        "dumps/CHATGPT_DOM_PLACEHOLDER.html",
-        "dumps/CODEX_DOM_PLACEHOLDER.html"
+        "dumps/CHATGPT_DOM.html",
+        "dumps/CODEX_DOM(mainpage).html"
       ]
     },
     {

--- a/metrics.md
+++ b/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
 total_tasks: 34
-completed_tasks: 4
-open_tasks: 30
+completed_tasks: 7
+open_tasks: 27
 critical_path: 7be14b8e

--- a/state.md
+++ b/state.md
@@ -1,5 +1,5 @@
 # Planner State
 
-graph_hash: d37924ce53e6ceddf20b9c3e991d96fac68a2e7f
+graph_hash: cf9eea862d9282ea31996023656c8d3b3df5fa31
 last_task: e19adce7
 active_agents: PlannerAgent


### PR DESCRIPTION
## Summary
- update manifest to reference new DOM dump files
- mark DOM acquisition milestone complete
- update project metrics and state
- log planner actions in DevDiary

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6886bc920000832e9bfb292e7a4b2c55