### PR TITLE
Planner updated DOM analysis status

### DIFF
--- a/DevDiary.md
+++ b/DevDiary.md
@@ -5,3 +5,4 @@
 - 55b22049 awaiting DOM dumps. Tasks 96a1b336 and a20ccaaa marked [u]. Cannot proceed with a057f02e.
 - USER LOG: Hello Planner Agent, i have replaced your placeholder dumps with `CHATGPT_DOM.html` and `CODEX_DOM(mainpage).html`
 - PlannerAgent: DOM dumps received. Updated manifest and metrics. Tasks 96a1b336 and a20ccaaa marked complete, enabling a057f02e.
+- PlannerAgent: Attempted a057f02e. Extracted ChatGPT selector 'textarea[name="prompt-textarea"]'. Codex DOM unclear; request simplified dump. Marked a057f02e [u].

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -52,7 +52,7 @@
   description: Analyze DOM dumps and document selectors
   why: Provide reliable hooks for scripts
   depends_on: [96a1b336, a20ccaaa]
-  status: []
+  status: [u]
 ---
 - uuid: b79cc393
   parent: 8d468653

--- a/metrics.md
+++ b/metrics.md
@@ -2,5 +2,5 @@
 
 total_tasks: 34
 completed_tasks: 7
-open_tasks: 27
+open_tasks: 26
 critical_path: 7be14b8e

--- a/state.md
+++ b/state.md
@@ -1,5 +1,5 @@
 # Planner State
 
-graph_hash: cf9eea862d9282ea31996023656c8d3b3df5fa31
-last_task: e19adce7
+graph_hash: 51dc1b88fe7643906d89588a43bb66f74c8de13b
+last_task: a057f02e
 active_agents: PlannerAgent

--- a/taskmap.svg
+++ b/taskmap.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="200">
   <style>text { font-family: Arial; font-size: 12px; }</style>
   <text x="10" y="20">bc756a2e - Planning [x]</text>
-  <text x="10" y="40">55b22049 - Gather DOM info []</text>
+  <text x="10" y="40">55b22049 - Gather DOM info [x]</text>
   <text x="10" y="60">8d468653 - Extension skeleton []</text>
   <text x="10" y="80">e8e121d2 - ChatGPT handlers []</text>
   <text x="10" y="100">295fe504 - Codex handlers []</text>


### PR DESCRIPTION
## Summary
- mark `a057f02e` task as needing user input
- log DOM analysis attempt in `DevDiary.md`
- update metrics and planner state
- refresh taskmap to show completed milestone

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886becce6f0832e9d049b9bb586b9d8