### PR TITLE
Add chat management API and update planning

### DIFF
--- a/DevDiary.md
+++ b/DevDiary.md
@@ -28,3 +28,8 @@
 - 6946d58d Documentation finalized with usage examples.
 - 3cbba0f3 Metrics and state updated for project completion.
 - 40927029 Final MetaStateChecker simulated.
+- 5a2f75cd Milestone for chat selection and new chat features.
+- 6e369182 Sidebar DOM parser implemented for chat listings.
+- ba6917bf selectChat function added for chat switching.
+- d274812e startNewChat function triggers keyboard shortcut.
+- da51f763 Documentation and metrics updated for new milestone.

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -194,3 +194,31 @@
   depends_on: [3cbba0f3]
   status: [x]
 ---
+- uuid: 6e369182
+  parent: 5a2f75cd
+  description: Parse sidebar DOM for chat ids and titles
+  why: Provide chat listing via getSidebarChats
+  depends_on: []
+  status: [x]
+---
+- uuid: ba6917bf
+  parent: 5a2f75cd
+  description: Implement selectChat to open chat by id or title
+  why: Allow agents to switch conversations
+  depends_on: [6e369182]
+  status: [x]
+---
+- uuid: d274812e
+  parent: 5a2f75cd
+  description: Implement startNewChat via keyboard shortcut
+  why: Enable automated new conversation creation
+  depends_on: [6e369182]
+  status: [x]
+---
+- uuid: da51f763
+  parent: 5a2f75cd
+  description: Update documentation, metrics and state for new features
+  why: Keep project records consistent
+  depends_on: [ba6917bf, d274812e]
+  status: [x]
+---

--- a/agent_tasks.md
+++ b/agent_tasks.md
@@ -60,3 +60,10 @@
   priority: 7
   status: [x]
 ---
+- uuid: 5a2f75cd
+  description: Add chat selection and new chat creation features
+  why: Manage multiple conversations via sidebar
+  depends_on: [7be14b8e]
+  priority: 8
+  status: [x]
+---

--- a/extension/content.js
+++ b/extension/content.js
@@ -46,6 +46,40 @@ function getChatGPTMessageContainer() {
   return document.querySelector('main');
 }
 
+function getSidebarChats() {
+  const sidebar = document.querySelector('nav');
+  if (!sidebar) return [];
+  return Array.from(sidebar.querySelectorAll('a[href*="/c/"]')).map(a => {
+    const href = a.getAttribute('href');
+    const id = href ? href.split('/c/')[1] : null;
+    return { id, title: a.textContent.trim(), element: a };
+  });
+}
+
+function selectChat(chatIdOrTitle) {
+  const chats = getSidebarChats();
+  const chat = chats.find(c => c.id === chatIdOrTitle || c.title === chatIdOrTitle);
+  if (chat && chat.element) {
+    chat.element.click();
+    return true;
+  }
+  return false;
+}
+
+function startNewChat() {
+  const evt = new KeyboardEvent('keydown', {
+    key: 'O',
+    code: 'KeyO',
+    ctrlKey: true,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true
+  });
+  document.dispatchEvent(evt);
+  const btn = document.querySelector('a,button[aria-label="New chat"]');
+  if (btn) btn.click();
+}
+
 function sendPromptToPage(prompt) {
   if (isChatGPTPage()) {
     const input = getChatGPTInput();
@@ -108,3 +142,10 @@ const observer = new MutationObserver(() => {
 });
 
 observer.observe(document.body, { childList: true, subtree: true });
+
+window.chatJacker = {
+  getSidebarChats,
+  selectChat,
+  startNewChat,
+  sendPromptToPage
+};

--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,17 @@
       "files": [
         "EXAMPLES.md"
       ]
+    },
+    {
+      "uuid": "5a2f75cd",
+      "files": [
+        "extension/content.js",
+        "agent_tasks.md",
+        "agent_prio.md",
+        "DevDiary.md",
+        "metrics.md",
+        "state.md"
+      ]
     }
   ]
 }

--- a/metrics.md
+++ b/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-total_tasks: 34
-completed_tasks: 34
+total_tasks: 39
+completed_tasks: 39
 open_tasks: 0
-critical_path: 7be14b8e
+critical_path: 5a2f75cd

--- a/state.md
+++ b/state.md
@@ -1,5 +1,5 @@
 # Planner State
 
-graph_hash: 51dc1b88fe7643906d89588a43bb66f74c8de13b
-last_task: 40927029
+graph_hash: f7e8a75d10e385119dd84fb2094f19335a92dbdb
+last_task: da51f763
 active_agents: ExecutorAgent


### PR DESCRIPTION
## Summary
- plan chat selection & new chat features in task files
- expose `getSidebarChats`, `selectChat` and `startNewChat` in content script
- document development progress and update manifest modules
- refresh metrics and planner state

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887101e1eb4832e9b799e7f3a889ea2