### PR TITLE
Planner: add Firefox parity plan

### DIFF
--- a/DevDiary.md
+++ b/DevDiary.md
@@ -42,3 +42,6 @@
 - fa8b39d3 jsdom tests verify chat functions; KeyboardEvent handled.
 - f1069bd2 TODO: monitor DOM for selector changes.
 - f1069bd2 DOM mismatch detection added to content and background scripts.
+- PlannerAgent: Analyzed Chrome extension for Firefox parity. Documented features: prompt queue, DOM helpers, completion detection, DOM mismatch reporting, chat management APIs.
+- PlannerAgent: Mapped chrome.* APIs to Firefox browser.* equivalents and noted service worker limitations.
+- PlannerAgent: Updated projectscope with Firefox architecture and created new milestone tasks.

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -272,3 +272,87 @@
   depends_on: [fa8b39d3]
   status: [x]
 ---
+---
+- uuid: cde0940e
+  parent: fb052e6a
+  description: Document Chrome extension features and event flow in DevDiary
+  why: Establish baseline for Firefox parity
+  depends_on: []
+  status: [x]
+---
+- uuid: 2fe0cd9f
+  parent: fb052e6a
+  description: Map Chrome APIs to Firefox equivalents
+  why: Identify required polyfills or replacements
+  depends_on: [cde0940e]
+  status: [x]
+---
+- uuid: 33430f27
+  parent: fb052e6a
+  description: Update projectscope with Firefox architecture notes
+  why: Guide future development tasks
+  depends_on: [2fe0cd9f]
+  status: [x]
+---
+- uuid: cdc27ea1
+  parent: 2ad5ecb2
+  description: Add browser_specific_settings to manifest and adjust permissions
+  why: Enable Firefox installation
+  depends_on: [33430f27]
+  status: [ ]
+---
+- uuid: 0a9fc997
+  parent: 2ad5ecb2
+  description: Update repository manifest with new Firefox artifacts
+  why: Track modified files for planning
+  depends_on: [cdc27ea1]
+  status: [ ]
+---
+- uuid: dbbd0a3f
+  parent: ede4b0e6
+  description: Polyfill browser APIs in background script
+  why: Ensure queue manager works in Firefox
+  depends_on: [0a9fc997]
+  status: [ ]
+---
+- uuid: 0af1e701
+  parent: 254d7d3e
+  description: Refactor content script to use browser APIs
+  why: Maintain DOM control in Firefox
+  depends_on: [dbbd0a3f]
+  status: [ ]
+---
+- uuid: eb00663d
+  parent: 8b03a0fe
+  description: Configure web-ext for building and running tests
+  why: Automate cross-browser validation
+  depends_on: [0af1e701]
+  status: [ ]
+---
+- uuid: 794a4c1b
+  parent: 8b03a0fe
+  description: Add Firefox run script to npm test workflow
+  why: Verify extension functions in Firefox
+  depends_on: [eb00663d]
+  status: [ ]
+---
+- uuid: 34996f4a
+  parent: a4a3ce6c
+  description: Perform manual QA in Firefox and fix issues
+  why: Ensure feature parity with Chrome
+  depends_on: [794a4c1b]
+  status: [ ]
+---
+- uuid: 28f4867c
+  parent: a4a3ce6c
+  description: Update README and USAGE with Firefox instructions
+  why: Document cross-browser installation steps
+  depends_on: [34996f4a]
+  status: [ ]
+---
+- uuid: 32bf3249
+  parent: 0ab9402c
+  description: Update metrics, state and run final MetaStateChecker
+  why: Close Firefox milestone and verify repo
+  depends_on: [28f4867c]
+  status: [ ]

--- a/agent_tasks.md
+++ b/agent_tasks.md
@@ -74,3 +74,52 @@
   depends_on: [5a2f75cd]
   priority: 9
   status: [x]
+---
+- uuid: fb052e6a
+  description: Plan Firefox extension parity and audit APIs
+  why: Ensure Chrome features map to Firefox capabilities
+  depends_on: [c3a1b840]
+  priority: 10
+  status: [ ]
+---
+- uuid: 2ad5ecb2
+  description: Convert manifest for Firefox compatibility
+  why: Provide browser_specific_settings and required permissions
+  depends_on: [fb052e6a]
+  priority: 11
+  status: [ ]
+---
+- uuid: ede4b0e6
+  description: Adapt background scripts for Firefox APIs
+  why: Service worker and messaging differences must be handled
+  depends_on: [2ad5ecb2]
+  priority: 12
+  status: [ ]
+---
+- uuid: 254d7d3e
+  description: Update content scripts for Firefox quirks
+  why: Ensure DOM helpers and messaging work across browsers
+  depends_on: [ede4b0e6]
+  priority: 13
+  status: [ ]
+---
+- uuid: 8b03a0fe
+  description: Add web-ext build and test pipeline
+  why: Automate packaging and testing under Firefox
+  depends_on: [254d7d3e]
+  priority: 14
+  status: [ ]
+---
+- uuid: a4a3ce6c
+  description: QA and documentation for Firefox release
+  why: Validate parity and guide users
+  depends_on: [8b03a0fe]
+  priority: 15
+  status: [ ]
+---
+- uuid: 0ab9402c
+  description: Finalize cross-browser support and update metrics
+  why: Complete project with Firefox parity
+  depends_on: [a4a3ce6c]
+  priority: 16
+  status: [ ]

--- a/manifest.json
+++ b/manifest.json
@@ -50,6 +50,42 @@
         "metrics.md",
         "state.md"
       ]
+    },
+    {
+      "uuid": "fb052e6a",
+      "files": [
+        "projectscope.md",
+        "agent_tasks.md",
+        "agent_prio.md",
+        "DevDiary.md",
+        "metrics.md",
+        "state.md",
+        "extension/manifest.json",
+        "extension/background.js",
+        "extension/content.js"
+      ]
+    },
+    {
+      "uuid": "2ad5ecb2",
+      "files": [
+        "extension/manifest.json",
+        "agent_tasks.md",
+        "agent_prio.md",
+        "DevDiary.md",
+        "metrics.md",
+        "state.md"
+      ]
+    },
+    {
+      "uuid": "0ab9402c",
+      "files": [
+        "README.md",
+        "USAGE.md",
+        "agent_tasks.md",
+        "agent_prio.md",
+        "metrics.md",
+        "state.md"
+      ]
     }
   ]
 }

--- a/metrics.md
+++ b/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-total_tasks: 47
-completed_tasks: 47
-open_tasks: 0
-critical_path: c3a1b840
+total_tasks: 66
+completed_tasks: 50
+open_tasks: 16
+critical_path: 0ab9402c

--- a/projectscope.md
+++ b/projectscope.md
@@ -12,3 +12,11 @@ Requirements:
 
 Note: 
 if required, Agents can Ask user for brower dumps / site source
+
+Firefox Support Goal:
+- Mirror Chrome extension functionality under Firefox.
+- Use browser.* APIs or polyfills for cross-browser messaging.
+- Provide a Firefox-optimized manifest with browser_specific_settings.
+- Setup web-ext for testing and packaging.
+- Ensure background scripts and content scripts behave the same.
+

--- a/state.md
+++ b/state.md
@@ -1,5 +1,5 @@
 # Planner State
 
-graph_hash: f7e8a75d10e385119dd84fb2094f19335a92dbdb
+graph_hash: 3e2b30069d5038fe396878065f2bb55980754d59
 last_task: f1069bd2
 active_agents: ExecutorAgent


### PR DESCRIPTION
## Summary
- document Chrome to Firefox porting plan in DevDiary
- update project scope with Firefox architecture goals
- plan new milestones and subtasks for Firefox support
- register new modules in manifest and update metrics/state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68892f528aa0832e9c5728bcbbb25919