### PR TITLE
Plan CLI milestones

### DIFF
--- a/agent_prio.md
+++ b/agent_prio.md
@@ -356,3 +356,299 @@
   why: Close Firefox milestone and verify repo
   depends_on: [28f4867c]
   status: [x]
+---
+- uuid: c2e4377a-b259-4c7a-939f-2ab3b60c3817
+  parent: e68c381e-a088-46cf-bc1e-1217a5b04356
+  description: Parse CLI scope and design new milestones
+  why: Establish tasks for Chat-Jacker CLI
+  depends_on: []
+  priority: 17
+  status: [x]
+---
+- uuid: 0c6dbf0f-fe22-4b00-93eb-e4eba4fd3fe1
+  parent: e68c381e-a088-46cf-bc1e-1217a5b04356
+  description: Update agent task files and manifest for CLI planning
+  why: Record DAG and update repository state
+  depends_on: [c2e4377a-b259-4c7a-939f-2ab3b60c3817]
+  priority: 17
+  status: [x]
+---
+- uuid: d01b9695-ced6-4a95-80ef-ccfbc32b3112
+  parent: e68c381e-a088-46cf-bc1e-1217a5b04356
+  description: Generate taskmap.svg and update metrics and state
+  why: Visualize plan and track progress
+  depends_on: [0c6dbf0f-fe22-4b00-93eb-e4eba4fd3fe1]
+  priority: 17
+  status: [x]
+---
+- uuid: 90425a4d-44e1-4342-ba31-97c7edb84829
+  parent: 8a132a08-2544-469e-bffc-929a17a555da
+  description: Setup Python environment and install Playwright
+  why: Provide dependencies for CLI execution
+  depends_on: [d01b9695-ced6-4a95-80ef-ccfbc32b3112]
+  priority: 18
+  status: []
+---
+- uuid: d6cc76b7-bde5-4c03-9a11-bbc42cf52e7d
+  parent: 8a132a08-2544-469e-bffc-929a17a555da
+  description: Create chatjacker_cli.py with argument parsing
+  why: Offer command line interface for automation
+  depends_on: [90425a4d-44e1-4342-ba31-97c7edb84829]
+  priority: 18
+  status: []
+---
+- uuid: 1030c9b5-f496-4b20-afad-9a81ed33c841
+  parent: 8a132a08-2544-469e-bffc-929a17a555da
+  description: Implement command dispatch and rich logging
+  why: Route actions and provide readable output
+  depends_on: [d6cc76b7-bde5-4c03-9a11-bbc42cf52e7d]
+  priority: 18
+  status: []
+---
+- uuid: 796956aa-313d-46e8-9ab6-ff85757de887
+  parent: 8a132a08-2544-469e-bffc-929a17a555da
+  description: Add CLI usage examples to USAGE.md
+  why: Document basic commands
+  depends_on: [1030c9b5-f496-4b20-afad-9a81ed33c841]
+  priority: 18
+  status: []
+---
+- uuid: 5a56f567-2647-4bf4-aeac-80b846c08044
+  parent: 0eec49b0-962f-4758-a3b7-6cad64c1e607
+  description: Configure Playwright to launch in headless mode
+  why: Allow automation without visible browser
+  depends_on: [796956aa-313d-46e8-9ab6-ff85757de887]
+  priority: 19
+  status: []
+---
+- uuid: dd9dd1ae-0c56-4068-829d-52d0d7b0b360
+  parent: 0eec49b0-962f-4758-a3b7-6cad64c1e607
+  description: Implement cookie persistence for sessions
+  why: Maintain login across runs
+  depends_on: [5a56f567-2647-4bf4-aeac-80b846c08044]
+  priority: 19
+  status: []
+---
+- uuid: ea085e7d-4b09-4848-ae13-bd6c5f12e48d
+  parent: 0eec49b0-962f-4758-a3b7-6cad64c1e607
+  description: Detect login requirement and prompt user once
+  why: Provide seamless authentication flow
+  depends_on: [dd9dd1ae-0c56-4068-829d-52d0d7b0b360]
+  priority: 19
+  status: []
+---
+- uuid: 6b6c7fa4-e01c-409e-96fa-2704acb39469
+  parent: 0eec49b0-962f-4758-a3b7-6cad64c1e607
+  description: Document session storage configuration
+  why: Explain how cookies are saved for reuse
+  depends_on: [ea085e7d-4b09-4848-ae13-bd6c5f12e48d]
+  priority: 19
+  status: []
+---
+- uuid: bff624ee-2039-4e17-9087-67ab97d53d33
+  parent: c88a4597-f135-4b9e-ba25-5016cdac80d9
+  description: Detect ChatGPT landing and chat pages
+  why: Ensure correct navigation logic
+  depends_on: [6b6c7fa4-e01c-409e-96fa-2704acb39469]
+  priority: 20
+  status: []
+---
+- uuid: 96fa2512-8015-4b50-8579-68c5186b6d6d
+  parent: c88a4597-f135-4b9e-ba25-5016cdac80d9
+  description: Implement list_chats scraping from sidebar
+  why: Enumerate available conversations
+  depends_on: [bff624ee-2039-4e17-9087-67ab97d53d33]
+  priority: 20
+  status: []
+---
+- uuid: 2e81faf8-2038-447d-b0d6-b877e884c4a4
+  parent: c88a4597-f135-4b9e-ba25-5016cdac80d9
+  description: Implement new_chat hotkey capture
+  why: Create new chat via automation
+  depends_on: [96fa2512-8015-4b50-8579-68c5186b6d6d]
+  priority: 20
+  status: []
+---
+- uuid: 69d4bc38-3275-4eed-a217-2cca7e079377
+  parent: c88a4597-f135-4b9e-ba25-5016cdac80d9
+  description: Implement search functionality and scrape results
+  why: Allow chat history search from CLI
+  depends_on: [2e81faf8-2038-447d-b0d6-b877e884c4a4]
+  priority: 20
+  status: []
+---
+- uuid: d654f7e7-22d2-415e-ae8e-5e5b3c7b741a
+  parent: c88a4597-f135-4b9e-ba25-5016cdac80d9
+  description: Send message in chat and capture response text
+  why: Enable full conversation interaction
+  depends_on: [69d4bc38-3275-4eed-a217-2cca7e079377]
+  priority: 20
+  status: []
+---
+- uuid: 6c77c44d-36d5-4465-8213-46e91a759d7b
+  parent: e57069a8-19ac-4e69-ab7b-cdc7224754a5
+  description: Detect Codex landing and task pages
+  why: Navigate properly within Codex
+  depends_on: [d654f7e7-22d2-415e-ae8e-5e5b3c7b741a]
+  priority: 21
+  status: []
+---
+- uuid: e69fd15a-694e-45b5-96ba-c7b7fc21cc56
+  parent: e57069a8-19ac-4e69-ab7b-cdc7224754a5
+  description: Implement list_tasks scraping
+  why: Enumerate available Codex tasks
+  depends_on: [6c77c44d-36d5-4465-8213-46e91a759d7b]
+  priority: 21
+  status: []
+---
+- uuid: efbc8251-1b37-443a-a3bc-9aba18909daf
+  parent: e57069a8-19ac-4e69-ab7b-cdc7224754a5
+  description: Implement open_task navigation to specific task page
+  why: Access task DOM for automation
+  depends_on: [e69fd15a-694e-45b5-96ba-c7b7fc21cc56]
+  priority: 21
+  status: []
+---
+- uuid: ba33660b-459f-4a8b-b1c2-e625a4ff76e1
+  parent: e57069a8-19ac-4e69-ab7b-cdc7224754a5
+  description: Implement send instructions within Codex task
+  why: Interact with Codex similar to ChatGPT
+  depends_on: [efbc8251-1b37-443a-a3bc-9aba18909daf]
+  priority: 21
+  status: []
+---
+- uuid: cb06dbe9-59ea-4875-b114-41289f1d78dd
+  parent: 9bd98fb3-d1ff-4915-8e35-0cf62002989c
+  description: Extract DOM selectors into selectors.js
+  why: Centralize query selectors for easy updates
+  depends_on: [ba33660b-459f-4a8b-b1c2-e625a4ff76e1]
+  priority: 22
+  status: []
+---
+- uuid: 19c48f09-338c-48ea-acbc-91452dbfd610
+  parent: 9bd98fb3-d1ff-4915-8e35-0cf62002989c
+  description: Inject selectors using page.evaluate in browser
+  why: Provide DOM hooks to action modules
+  depends_on: [cb06dbe9-59ea-4875-b114-41289f1d78dd]
+  priority: 22
+  status: []
+---
+- uuid: 12465777-2727-4a38-931a-a2c22ff5e0d7
+  parent: 9bd98fb3-d1ff-4915-8e35-0cf62002989c
+  description: Refactor ChatGPT and Codex modules to use selector layer
+  why: Ensure consistency across targets
+  depends_on: [19c48f09-338c-48ea-acbc-91452dbfd610]
+  priority: 22
+  status: []
+---
+- uuid: cf497abe-0a7c-423a-8ef5-741af9916e18
+  parent: 47663495-dcf7-4c84-801c-26024dbc8153
+  description: Design JSON result schema for CLI output
+  why: Standardize response format
+  depends_on: [12465777-2727-4a38-931a-a2c22ff5e0d7]
+  priority: 23
+  status: []
+---
+- uuid: b76ed4ee-e84e-42f6-aa05-e54521815e74
+  parent: 47663495-dcf7-4c84-801c-26024dbc8153
+  description: Implement output formatting and rich logging
+  why: Provide readable JSON results for chaining
+  depends_on: [cf497abe-0a7c-423a-8ef5-741af9916e18]
+  priority: 23
+  status: []
+---
+- uuid: 75ecdd96-8406-4b68-a274-589463ccb73f
+  parent: 47663495-dcf7-4c84-801c-26024dbc8153
+  description: Write tests validating JSON output structure
+  why: Prevent regressions in result formatting
+  depends_on: [b76ed4ee-e84e-42f6-aa05-e54521815e74]
+  priority: 23
+  status: []
+---
+- uuid: 3251a125-5538-4787-80d3-0a6db4e48996
+  parent: a84026d5-c998-4af0-bb5f-9a04c985c54c
+  description: Implement --plan mode to read task files
+  why: Allow agent-driven workflows
+  depends_on: [75ecdd96-8406-4b68-a274-589463ccb73f]
+  priority: 24
+  status: []
+---
+- uuid: 3848a924-640a-41f6-971f-69c2c9a1d50b
+  parent: a84026d5-c998-4af0-bb5f-9a04c985c54c
+  description: Add action chaining across multiple steps
+  why: Execute plans sequentially without user input
+  depends_on: [3251a125-5538-4787-80d3-0a6db4e48996]
+  priority: 24
+  status: []
+---
+- uuid: f87b6c31-5a3c-49c0-9a3e-bdc5fdfb4c8f
+  parent: a84026d5-c998-4af0-bb5f-9a04c985c54c
+  description: Document sample plan files and usage
+  why: Help agents adopt automation workflows
+  depends_on: [3848a924-640a-41f6-971f-69c2c9a1d50b]
+  priority: 24
+  status: []
+---
+- uuid: bd3649bb-22ea-4f7f-b008-dbf7dc9123ae
+  parent: 00c0a86e-7297-4f3a-ad56-09014022a908
+  description: Add parallel browser context support
+  why: Execute multiple tasks simultaneously
+  depends_on: [f87b6c31-5a3c-49c0-9a3e-bdc5fdfb4c8f]
+  priority: 25
+  status: []
+---
+- uuid: 585b4251-aa85-4cc5-9266-6b3cefcfb630
+  parent: 00c0a86e-7297-4f3a-ad56-09014022a908
+  description: Implement stealth mode for Playwright sessions
+  why: Reduce detection risk during automation
+  depends_on: [bd3649bb-22ea-4f7f-b008-dbf7dc9123ae]
+  priority: 25
+  status: []
+---
+- uuid: fd3cf7d7-dce5-47a9-8944-14aeb425e864
+  parent: 00c0a86e-7297-4f3a-ad56-09014022a908
+  description: Create modular task templates for workflows
+  why: Reuse common automation patterns
+  depends_on: [585b4251-aa85-4cc5-9266-6b3cefcfb630]
+  priority: 25
+  status: []
+---
+- uuid: e9d3583b-8f3c-47f3-b440-061ec9479f88
+  parent: 00c0a86e-7297-4f3a-ad56-09014022a908
+  description: Integrate Codex output with GitHub repositories
+  why: Automatically fetch and commit generated code
+  depends_on: [fd3cf7d7-dce5-47a9-8944-14aeb425e864]
+  priority: 25
+  status: []
+---
+- uuid: 19e880cd-9ad3-4a35-b15d-de77e5a0c9c9
+  parent: 00c0a86e-7297-4f3a-ad56-09014022a908
+  description: Document stretch features and configuration
+  why: Guide advanced users through optional capabilities
+  depends_on: [e9d3583b-8f3c-47f3-b440-061ec9479f88]
+  priority: 25
+  status: []
+---
+- uuid: a4f95ada-7e42-4398-9b17-87f705737242
+  parent: b6a02b30-f40b-47ba-a82f-18623680aa8c
+  description: Update README and USAGE with CLI instructions
+  why: Provide documentation for new tool
+  depends_on: [19e880cd-9ad3-4a35-b15d-de77e5a0c9c9]
+  priority: 26
+  status: []
+---
+- uuid: a85f0068-0b03-40b3-91a6-5c9a8e45f81f
+  parent: b6a02b30-f40b-47ba-a82f-18623680aa8c
+  description: Run full test suite and fix discovered issues
+  why: Ensure CLI stability before release
+  depends_on: [a4f95ada-7e42-4398-9b17-87f705737242]
+  priority: 26
+  status: []
+---
+- uuid: 0633a47b-8c51-418d-bea9-cf7137db9cb9
+  parent: b6a02b30-f40b-47ba-a82f-18623680aa8c
+  description: Execute MetaStateChecker and close project
+  why: Final verification of all milestones
+  depends_on: [a85f0068-0b03-40b3-91a6-5c9a8e45f81f]
+  priority: 26
+  status: []

--- a/agent_tasks.md
+++ b/agent_tasks.md
@@ -123,3 +123,73 @@
   depends_on: [a4a3ce6c]
   priority: 16
   status: [x]
+---
+- uuid: e68c381e-a088-46cf-bc1e-1217a5b04356
+  description: Plan Chat-Jacker CLI milestones and tasks
+  why: Provide structured roadmap for CLI features
+  depends_on: [0ab9402c]
+  priority: 17
+  status: [x]
+---
+- uuid: 8a132a08-2544-469e-bffc-929a17a555da
+  description: Implement core CLI framework with argument parsing
+  why: Provide entrypoint for headless automation
+  depends_on: [e68c381e-a088-46cf-bc1e-1217a5b04356]
+  priority: 18
+  status: []
+---
+- uuid: 0eec49b0-962f-4758-a3b7-6cad64c1e607
+  description: Build headless browser launcher with persistent sessions
+  why: Enable login reuse and navigation without UI
+  depends_on: [8a132a08-2544-469e-bffc-929a17a555da]
+  priority: 19
+  status: []
+---
+- uuid: c88a4597-f135-4b9e-ba25-5016cdac80d9
+  description: Add ChatGPT action support for conversations
+  why: Interact with ChatGPT via CLI
+  depends_on: [0eec49b0-962f-4758-a3b7-6cad64c1e607]
+  priority: 20
+  status: []
+---
+- uuid: e57069a8-19ac-4e69-ab7b-cdc7224754a5
+  description: Add Codex action support for task automation
+  why: Control Codex tasks from CLI
+  depends_on: [0eec49b0-962f-4758-a3b7-6cad64c1e607]
+  priority: 21
+  status: []
+---
+- uuid: 9bd98fb3-d1ff-4915-8e35-0cf62002989c
+  description: Create selector injection layer for DOM hooks
+  why: Reuse Chat-Jacker selectors across targets
+  depends_on: [c88a4597-f135-4b9e-ba25-5016cdac80d9, e57069a8-19ac-4e69-ab7b-cdc7224754a5]
+  priority: 22
+  status: []
+---
+- uuid: 47663495-dcf7-4c84-801c-26024dbc8153
+  description: Implement JSON output layer for CLI results
+  why: Provide structured output for agents
+  depends_on: [9bd98fb3-d1ff-4915-8e35-0cf62002989c]
+  priority: 23
+  status: []
+---
+- uuid: a84026d5-c998-4af0-bb5f-9a04c985c54c
+  description: Build agent integration hooks and plan mode
+  why: Allow chained actions from task files
+  depends_on: [47663495-dcf7-4c84-801c-26024dbc8153]
+  priority: 24
+  status: []
+---
+- uuid: 00c0a86e-7297-4f3a-ad56-09014022a908
+  description: Implement stretch goals like parallel execution and stealth
+  why: Provide optional advanced features
+  depends_on: [a84026d5-c998-4af0-bb5f-9a04c985c54c]
+  priority: 25
+  status: []
+---
+- uuid: b6a02b30-f40b-47ba-a82f-18623680aa8c
+  description: Finalize CLI, documentation and run MetaStateChecker
+  why: Ensure CLI readiness and clean project state
+  depends_on: [a84026d5-c998-4af0-bb5f-9a04c985c54c]
+  priority: 26
+  status: []

--- a/manifest.json
+++ b/manifest.json
@@ -99,6 +99,76 @@
         "metrics.md",
         "state.md"
       ]
+    },
+    {
+      "uuid": "e68c381e-a088-46cf-bc1e-1217a5b04356",
+      "files": [
+        "projectscope.md",
+        "agent_tasks.md",
+        "agent_prio.md",
+        "metrics.md",
+        "state.md",
+        "taskmap.svg",
+        "manifest.json"
+      ]
+    },
+    {
+      "uuid": "8a132a08-2544-469e-bffc-929a17a555da",
+      "files": [
+        "chatjacker_cli.py",
+        "README.md",
+        "USAGE.md"
+      ]
+    },
+    {
+      "uuid": "0eec49b0-962f-4758-a3b7-6cad64c1e607",
+      "files": [
+        "chatjacker_cli.py",
+        "cli/browser.py"
+      ]
+    },
+    {
+      "uuid": "c88a4597-f135-4b9e-ba25-5016cdac80d9",
+      "files": [
+        "targets/chatgpt.py"
+      ]
+    },
+    {
+      "uuid": "e57069a8-19ac-4e69-ab7b-cdc7224754a5",
+      "files": [
+        "targets/codex.py"
+      ]
+    },
+    {
+      "uuid": "9bd98fb3-d1ff-4915-8e35-0cf62002989c",
+      "files": [
+        "selectors.js"
+      ]
+    },
+    {
+      "uuid": "47663495-dcf7-4c84-801c-26024dbc8153",
+      "files": [
+        "src/output.py"
+      ]
+    },
+    {
+      "uuid": "a84026d5-c998-4af0-bb5f-9a04c985c54c",
+      "files": [
+        "src/agent_hooks.py"
+      ]
+    },
+    {
+      "uuid": "00c0a86e-7297-4f3a-ad56-09014022a908",
+      "files": [
+        "src/advanced.py"
+      ]
+    },
+    {
+      "uuid": "b6a02b30-f40b-47ba-a82f-18623680aa8c",
+      "files": [
+        "README.md",
+        "USAGE.md"
+      ]
     }
   ]
 }

--- a/metrics.md
+++ b/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-total_tasks: 66
-completed_tasks: 66
-open_tasks: 0
-critical_path: 0ab9402c
+total_tasks: 112
+completed_tasks: 70
+open_tasks: 42
+critical_path: b6a02b30-f40b-47ba-a82f-18623680aa8c

--- a/state.md
+++ b/state.md
@@ -1,5 +1,5 @@
 # Planner State
 
-graph_hash: 8a2ed8f60ab8adcb0641bce618835341264cf906
-last_task: 32bf3249
+graph_hash: a868626d0541514f442bcab19f84f3da3a35c449
+last_task: d01b9695-ced6-4a95-80ef-ccfbc32b3112
 active_agents: ExecutorAgent

--- a/taskmap.svg
+++ b/taskmap.svg
@@ -1,10 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="220">
   <style>text { font-family: Arial; font-size: 12px; }</style>
-  <text x="10" y="20">bc756a2e - Planning [x]</text>
-  <text x="10" y="40">55b22049 - Gather DOM info [x]</text>
-  <text x="10" y="60">8d468653 - Extension skeleton []</text>
-  <text x="10" y="80">e8e121d2 - ChatGPT handlers []</text>
-  <text x="10" y="100">295fe504 - Codex handlers []</text>
-  <text x="10" y="120">a57eb7aa - Queue & capture []</text>
-  <text x="10" y="140">7be14b8e - Finalize []</text>
+  <text x="10" y="20">e68c381e - CLI planning [x]</text>
+  <text x="10" y="40">8a132a08 - Core CLI framework []</text>
+  <text x="10" y="60">0eec49b0 - Headless browser []</text>
+  <text x="10" y="80">c88a4597 - ChatGPT support []</text>
+  <text x="10" y="100">e57069a8 - Codex support []</text>
+  <text x="10" y="120">9bd98fb3 - Selector layer []</text>
+  <text x="10" y="140">47663495 - Output layer []</text>
+  <text x="10" y="160">a84026d5 - Agent hooks []</text>
+  <text x="10" y="180">00c0a86e - Stretch goals []</text>
+  <text x="10" y="200">b6a02b30 - Finalize CLI []</text>
 </svg>


### PR DESCRIPTION
## Summary
- outline new Chat-Jacker CLI milestones and subtasks
- track tasks in metrics and state
- expand manifest modules for CLI roadmap
- update Gantt chart for new work

## Testing
- `node test/run_tests.js`

------
https://chatgpt.com/codex/tasks/task_e_68894d7c6abc832e9cb4391290263a6a